### PR TITLE
Fix: 운영 환경 login 과정에서 header를 못읽는 문제

### DIFF
--- a/src/main/java/shop/yesaladin/front/config/SecurityConfig.java
+++ b/src/main/java/shop/yesaladin/front/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                 UsernamePasswordAuthenticationFilter.class
         );
 
+        http.headers().frameOptions().sameOrigin();
         http.csrf().disable();
         http.cors().disable();
         return http.build();

--- a/src/main/java/shop/yesaladin/front/config/SecurityConfig.java
+++ b/src/main/java/shop/yesaladin/front/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                 UsernamePasswordAuthenticationFilter.class
         );
 
-        http.headers().frameOptions().sameOrigin();
+        http.headers().defaultsDisabled().frameOptions().sameOrigin();
         http.csrf().disable();
         http.cors().disable();
         return http.build();


### PR DESCRIPTION
다음 문제의 확인 목적으로 http header 설정을 다음과 같이 임시 수정합니다.

현재 front server의 운영 환경에서 response header를 읽어오지 못해 `CustomFailureHandler`이 동작하여 로그인이 안되고 있습니다.

![log](https://user-images.githubusercontent.com/60968342/215307452-ff7fc591-1fd9-44e3-9da5-c64d4f792bb9.png)
log 상에선 auth 서버까진 정확하게 동작합니다. 응답 받은 front에서 읽지를 못하고있습니다.

front server가 현재 2대 라서 경로를 못찾고있는 것인지 모르겠네요...

해당 `CustomFailureHandler`는 login 과정 시 응답 헤더 중 UUID, Authorization 이라는 커스텀 헤더의 값이 비었을 경우 동작합니다.