### PR TITLE
Fix: 회원가입 form 관련 검증 fix

### DIFF
--- a/src/main/java/shop/yesaladin/front/member/dto/SignUpRequestDto.java
+++ b/src/main/java/shop/yesaladin/front/member/dto/SignUpRequestDto.java
@@ -25,39 +25,37 @@ public class SignUpRequestDto {
 
     @NotBlank
     @Size(min = 2, max = 50)
+    @Pattern(regexp = "^[가-힣a-zA-Z]{2,50}$", message = "이름은 한글 또는 영어 2자에서 50자까지 입력 가능합니다.")
     private String name;
 
     @NotBlank
     @Size(min = 2, max = 15)
     @Pattern(regexp = "^[가-힣ㄱ-ㅎa-zA-Z0-9._-]{2,15}$",
-            message = "숫자, 영어, 한국어와 언더스코어, 공백을 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다.")
+            message = "숫자, 영어, 한국어와 언더스코어를 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다.")
     private String nickname;
 
     @NotBlank
     @Size(min = 8, max = 15)
-    @Pattern(regexp = "^[a-zA-Z0-9]{8,15}$", message = "영문 또는 숫자로 8자 이상 15자 이하만 가능 합니다")
+    @Pattern(regexp = "^[a-zA-Z0-9]{8,15}$", message = "영문 또는 숫자로 8자 이상 15자 이하만 가능 합니다.")
     private String loginId;
 
-    @Email
-    @NotBlank
+    @Email(message = "이메일 양식을 지켜주세요.")
+    @NotBlank(message = "email을 입력해주세요.")
     @Size(max = 100)
     private String email;
 
-    @NotBlank
-    @Size(min = 11, max = 11)
+    @NotBlank(message = "전화번호를 입력해주세요.")
+    @Size(min = 11, max = 11, message = "- 없이 11자 입력해주세요.")
     private String phone;
 
     @NotBlank
-    @Size(min = 8)
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
-            message = "최소 8자, 하나 이상의 문자와 하나의 숫자 및 하나의 특수 문자")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
+            message = "비밀번호는 최소 8자 최대 20자, 하나 이상의 문자와 하나의 숫자 및 하나의 특수 문자가 들어가야 합니다.")
     private String password;
 
-    @NotBlank
-    @Size(min = 8, max = 8)
-    @Pattern(regexp = "^[0-9]{8}")
+    @NotBlank(message = "생년월일을 체크해 주세요.")
     private String birth;
 
-    @NotBlank
+    @NotBlank(message = "성별을 체크해 주세요.")
     private String gender;
 }

--- a/src/main/java/shop/yesaladin/front/oauth/dto/Oauth2SignUpRequestDto.java
+++ b/src/main/java/shop/yesaladin/front/oauth/dto/Oauth2SignUpRequestDto.java
@@ -25,6 +25,7 @@ public class Oauth2SignUpRequestDto {
 
     @NotBlank
     @Size(min = 2, max = 50)
+    @Pattern(regexp = "^[가-힣a-zA-Z]{2,50}$", message = "이름은 한글 또는 영어 2자에서 50자까지 입력 가능합니다.")
     private String name;
 
     @NotBlank
@@ -37,23 +38,21 @@ public class Oauth2SignUpRequestDto {
     @Size(min = 1, max = 50)
     private String loginId;
 
-    @Email
-    @NotBlank
+    @Email(message = "이메일 양식을 지켜주세요.")
+    @NotBlank(message = "email을 입력해주세요.")
     @Size(max = 100)
     private String email;
 
-    @NotBlank
-    @Size(min = 11, max = 11)
+    @NotBlank(message = "전화번호를 입력해주세요.")
+    @Size(min = 11, max = 11, message = "- 없이 11자 입력해주세요.")
     private String phone;
 
     @NotBlank
     private String password;
 
-    @NotBlank
-    @Size(min = 8, max = 8)
-    @Pattern(regexp = "^[0-9]{8}")
+    @NotBlank(message = "생년월일을 체크해 주세요.")
     private String birth;
 
-    @NotBlank
+    @NotBlank(message = "성별을 체크해 주세요.")
     private String gender;
 }

--- a/src/main/resources/static/js/member/oauthSignup.js
+++ b/src/main/resources/static/js/member/oauthSignup.js
@@ -2,7 +2,7 @@ function nicknameCheck() {
   let nicknameCheckBtn = document.getElementById('nicknameCheckBtn');
   let nicknameInput = document.getElementById('nickname');
   let nicknameVal = nicknameInput.value;
-  let nicknameRegex = /^.*(?=.*[a-z])(?=.*[a-z\d])(?=.{2,8}).*$/;
+  let nicknameRegex = /^[가-힣ㄱ-ㅎa-zA-Z0-9._-]{2,15}$/;
   let emptyRegex = /\s/g;
 
   if (nicknameRegex.test(nicknameVal) && !emptyRegex.test(nicknameVal)) {
@@ -23,7 +23,7 @@ function nicknameCheck() {
       })
     });
   } else {
-    alert('닉네임은 영문으로 2자 이상 15자 이하만 가능합니다.');
+    alert('숫자, 영어, 한국어와 언더스코어를 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다.')
   }
 }
 
@@ -58,7 +58,6 @@ function emailCheck() {
 
 function phoneCheck() {
   let phoneCheckBtn = document.getElementById('phoneCheckBtn');
-  let createAccountBtn = document.getElementById('createAccountBtn');
   let phoneInput = document.getElementById('phone');
   let phoneVal = phoneInput.value;
   let phoneRegex = /^\d{11}$/;
@@ -76,7 +75,6 @@ function phoneCheck() {
           alert('사용 가능한 휴대폰 번호 입니다.');
           phoneInput.readOnly = true;
           phoneCheckBtn.disabled = true;
-          createAccountBtn.disabled = false;
         } else {
           alert('이미 사용 중인 휴대폰 번호 입니다.');
         }
@@ -85,4 +83,36 @@ function phoneCheck() {
   } else {
     alert('휴대폰 번호를 - 없이 11자 입력해주세요.');
   }
+}
+
+function finalCheckEvent() {
+  let createAccountBtn = document.getElementById('createAccountBtn');
+  let genderVal = document.getElementById('gender').value;
+  let birthVal = document.getElementById('datepicker-icon-prepend').value;
+
+  let emptyRegex = /\s/g;
+
+  if (!emptyRegex.test(genderVal) && !emptyRegex.test(birthVal)) {
+    createAccountBtn.disabled = false;
+  } else {
+    alert('성별과 생년월일을 선택해 주세요.');
+  }
+}
+
+function againInputCheckEvent() {
+  let createAccountBtn = document.getElementById('createAccountBtn');
+  let phoneCheckBtn = document.getElementById('phoneCheckBtn');
+  let phoneInput = document.getElementById('phone');
+  let emailCheckBtn = document.getElementById('emailCheckBtn');
+  let emailInput = document.getElementById('email');
+  let nicknameCheckBtn = document.getElementById('nicknameCheckBtn');
+  let nicknameInput = document.getElementById('nickname');
+
+  nicknameInput.readOnly = false;
+  nicknameCheckBtn.disabled = false;
+  emailInput.readOnly = false;
+  emailCheckBtn.disabled = false;
+  phoneInput.readOnly = false;
+  phoneCheckBtn.disabled = false;
+  createAccountBtn.disabled = true;
 }

--- a/src/main/resources/static/js/member/signup.js
+++ b/src/main/resources/static/js/member/signup.js
@@ -2,7 +2,7 @@ function nicknameCheck() {
   let nicknameCheckBtn = document.getElementById('nicknameCheckBtn');
   let nicknameInput = document.getElementById('nickname');
   let nicknameVal = nicknameInput.value;
-  let nicknameRegex = /^.*(?=.*[a-z])(?=.*[a-z\d])(?=.{2,8}).*$/;
+  let nicknameRegex = /^[가-힣ㄱ-ㅎa-zA-Z0-9._-]{2,15}$/;
   let emptyRegex = /\s/g;
 
   if (nicknameRegex.test(nicknameVal) && !emptyRegex.test(nicknameVal)) {
@@ -23,7 +23,7 @@ function nicknameCheck() {
       })
     });
   } else {
-    alert('닉네임은 영문으로 2자 이상 15자 이하만 가능합니다.');
+    alert('숫자, 영어, 한국어와 언더스코어를 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다.');
   }
 }
 
@@ -31,7 +31,7 @@ function loginIdCheck() {
   let loginIdCheckBtn = document.getElementById('loginIdCheckBtn');
   let loginIdInput = document.getElementById('loginId');
   let loginIdVal = loginIdInput.value;
-  let loginIdRegex = /([a-zA-Z0-9]{8,15})/g;
+  let loginIdRegex = /^[a-zA-Z0-9]{8,15}$/g;
   let emptyRegex = /\s/g;
 
   if (loginIdRegex.test(loginIdVal) && !emptyRegex.test(loginIdVal)) {
@@ -116,24 +116,64 @@ function phoneCheck() {
 
 function passwordCheckEvent() {
   let passwordCheckBtn = document.getElementById('passwordCheckBtn');
-  let createAccountBtn = document.getElementById('createAccountBtn');
   let password = document.getElementById('password');
   let passwordVal = document.getElementById('password').value;
   let passwordCheck = document.getElementById('passwordCheck');
   let passwordCheckVal = document.getElementById('passwordCheck').value;
 
-  let passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/g
+  let passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,20}$/g
   let emptyRegex = /\s/g;
 
   if (passwordVal !== passwordCheckVal) {
     alert('Password가 일치하지 않습니다.');
   } else if (!passwordRegex.test(passwordVal) || emptyRegex.test(passwordVal)) {
-    alert('Password는 최소 8자, 하나 이상의 문자와 하나의 숫자 및 하나의 특수 문자로 입력해주세요.')
+    alert('Password는 최소 8자, 하나 이상의 문자와 하나의 숫자 및 하나의 특수 문자로 입력해주세요.');
   } else {
     console.log("ok");
     password.readOnly = true;
     passwordCheck.readOnly = true;
-    passwordCheckBtn.disabled = true;
-    createAccountBtn.disabled = false;
+    passwordCheckBtn.disabl를ed = true;
   }
+}
+
+function finalCheckEvent() {
+  let createAccountBtn = document.getElementById('createAccountBtn');
+  let genderVal = document.getElementById('gender').value;
+  let birthVal = document.getElementById('datepicker-icon-prepend').value;
+
+  let emptyRegex = /\s/g;
+
+  if (!emptyRegex.test(genderVal) && !emptyRegex.test(birthVal)) {
+    createAccountBtn.disabled = false;
+  } else {
+    alert('성별과 생년월일을 선택해 주세요.');
+  }
+}
+
+function againInputCheckEvent() {
+  let createAccountBtn = document.getElementById('createAccountBtn');
+  let passwordCheckBtn = document.getElementById('passwordCheckBtn');
+  let password = document.getElementById('password');
+  let passwordCheck = document.getElementById('passwordCheck');
+  let phoneCheckBtn = document.getElementById('phoneCheckBtn');
+  let phoneInput = document.getElementById('phone');
+  let emailCheckBtn = document.getElementById('emailCheckBtn');
+  let emailInput = document.getElementById('email');
+  let loginIdCheckBtn = document.getElementById('loginIdCheckBtn');
+  let loginIdInput = document.getElementById('loginId');
+  let nicknameCheckBtn = document.getElementById('nicknameCheckBtn');
+  let nicknameInput = document.getElementById('nickname');
+
+  nicknameInput.readOnly = false;
+  nicknameCheckBtn.disabled = false;
+  loginIdInput.readOnly = false;
+  loginIdCheckBtn.disabled = false;
+  emailInput.readOnly = false;
+  emailCheckBtn.disabled = false;
+  phoneInput.readOnly = false;
+  phoneCheckBtn.disabled = false;
+  password.readOnly = false;
+  passwordCheck.readOnly = false;
+  passwordCheckBtn.disabled = false;
+  createAccountBtn.disabled = true;
 }

--- a/src/main/resources/templates/auth/oauth-signup.html
+++ b/src/main/resources/templates/auth/oauth-signup.html
@@ -51,7 +51,7 @@
             <div class="mb-3">
               <label class="form-label">이름</label>
               <input type="text" class="form-control" id="name" th:name="name" placeholder="이름"
-                     pattern="^.*(?=.*[가-힣a-z])(?=^.{2,200}).*$"
+                     pattern="^.*(?=.*[가-힣a-z])(?=^.{2,50}).*$"
                      required>
               <div class="invalid-feedback">
                 이름을 입력해주세요.
@@ -61,10 +61,7 @@
               <label class="form-label">닉네임</label>
               <input type="text" class="form-control" id="nickname" th:name="nickname"
                      pattern="^[가-힣ㄱ-ㅎa-zA-Z0-9._-]{2,15}$"
-                     placeholder="숫자, 영어, 한국어와 언더스코어, 공백을 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다." required>
-              <div class="invalid-feedback">
-                숫자, 영어, 한국어와 언더스코어, 공백을 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다.
-              </div>
+                     placeholder="숫자, 영어, 한국어와 언더스코어를 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다." required>
               <div class="button-box">
                 <button class="nicknameCheckBtn" id="nicknameCheckBtn" type="button" onclick="nicknameCheck()">중복 확인</button>
               </div>
@@ -76,9 +73,6 @@
               <input type="email" class="form-control" id="email" th:name="email" placeholder="이메일"
                      pattern="^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$"
                      required>
-              <div class="invalid-feedback">
-                이메일 주소를 입력해주세요.
-              </div>
               <div class="button-box">
                 <button class="emailCheckBtn" id="emailCheckBtn" type="button" onclick="emailCheck()">중복 확인</button>
               </div>
@@ -88,20 +82,29 @@
               <input type="text" class="form-control" id="phone" th:name="phone"
                      pattern="([0-9]{11})"
                      placeholder="휴대폰 번호 ex) 01012345678" required>
-              <div class="invalid-feedback">
-                휴대폰 번호를 - 없이 11자 입력해주세요.
-              </div>
               <div class="button-box">
                 <button class="phoneCheckBtn" id="phoneCheckBtn" type="button" onclick="phoneCheck()">중복 확인</button>
               </div>
             </div>
             <div class="mb-3">
               <label class="form-label">생년월일</label>
-              <input type="text" class="form-control" id="birth" placeholder="예시: 20230101"
-                     pattern="([0-9]{8})"
-                     th:name="birth" required>
-              <div class="invalid-feedback">
-                생년월일을 정확하게 입력해주세요.
+              <div class="input-icon">
+                <span class="input-icon-addon"><!-- Download SVG icon from http://tabler-icons.io/i/calendar -->
+                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                       viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                       stroke-linecap="round" stroke-linejoin="round"><path stroke="none"
+                                                                            d="M0 0h24v24H0z"
+                                                                            fill="none"></path><rect
+                      x="4" y="5" width="16" height="16" rx="2"></rect><line x1="16" y1="3" x2="16"
+                                                                             y2="7"></line><line
+                      x1="8" y1="3" x2="8" y2="7"></line><line x1="4" y1="11" x2="20"
+                                                               y2="11"></line><line x1="11" y1="15"
+                                                                                    x2="12"
+                                                                                    y2="15"></line><line
+                      x1="12" y1="15" x2="12" y2="18"></line></svg>
+                </span>
+                <input type="date" class="form-control" name="birth"
+                       id="datepicker-icon-prepend" value="" required>
               </div>
             </div>
             <div class="mb-3">
@@ -113,11 +116,12 @@
                     <option value="MALE">남성</option>
                     <option value="FEMALE">여성</option>
                   </select>
-                  <div class="invalid-feedback">
-                    성별을 선택해주세요.
-                  </div>
                 </div>
               </div>
+            </div>
+            <div class="button-box">
+              <button class="finalCheckBtn" id="finalCheckBtn" type="button" onclick="finalCheckEvent()">입력 완료 확인</button>
+              <button class="againCheckBtn" id="againCheckBtn" type="button" onclick="againInputCheckEvent()">다시 입력하시겠습니까?</button>
             </div>
             <div class="form-footer">
               <button type="submit" class="btn btn-primary w-100" id="createAccountBtn" disabled>Create new account</button>
@@ -131,51 +135,5 @@
   <!-- TODO 4 : footer -->
   <div th:replace="~{common/fragments/footer :: fragment-footer}"></div>
 </div>
-<script>
-  window.addEventListener('load', () => {
-    const signupForm = document.getElementsByClassName('signup-form');
-
-    let emptyRegex = /\s/g;
-    let nameRegex = /^.*(?=.*[가-힣a-z])(?=^.{2,200}).*$/;
-    let nicknameRegex = /^[가-힣ㄱ-ㅎa-zA-Z0-9._-]{2,15}$/;
-    let birthdayRegex = /^.*(?=.*\d)(?=^.{6}).*$/;
-    let phoneRegex = /^\d{11}$/;
-
-    Array.prototype.filter.call(signupForm, (signupForm) => {
-      signupForm.addEventListener('submit', function (event) {
-        if (signupForm.checkValidity() === false) {
-          event.preventDefault();
-          event.stopPropagation();
-        }
-
-        let nameVal = document.getElementById('name').value;
-        if (!nameRegex.test(nameVal) || emptyRegex.test(nameVal)) {
-          alert('이름을 올바르게 입력해주세요.')
-          return false;
-        }
-
-        let nicknameVal = document.getElementById('nickname').value;
-        if (!nicknameRegex.test(nicknameVal) || emptyRegex.test(nicknameVal)) {
-          alert('숫자, 영어, 한국어와 언더스코어, 공백을 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다.');
-          return false;
-        }
-
-        let birthdayVal = document.getElementById('birth').value;
-        if (!birthdayRegex.test(birthdayVal) || emptyRegex.test(birthdayVal)) {
-          alert('생년월일 8자를 - 없이 입력해주세요. ex) 20230101');
-          return false;
-        }
-
-        let phoneVal = document.getElementById('phone').value;
-        if (!phoneRegex.test(phoneVal) || emptyRegex.test(phoneVal)) {
-          alert('휴대폰 번호를 - 없이 13자 입력해주세요.');
-          return false;
-        }
-
-        signupForm.classList.add('was-validated');
-      }, false);
-    });
-  }, false);
-</script>
 </body>
 </html>

--- a/src/main/resources/templates/auth/signup-form.html
+++ b/src/main/resources/templates/auth/signup-form.html
@@ -44,27 +44,23 @@
           <a href="." class="navbar-brand navbar-brand-autodark"><img src="./static/logo.svg"
                                                                       height="36" alt=""></a>
         </div>
-        <form class="signup-form" id="signup-form" action="/members/signup" method="post"
+        <form class="signup-form" id="signup-form" action="/members/signup" method="post" th:object="${member}"
               autocomplete="off" novalidate="">
           <div class="card-body">
             <h2 class="card-title text-center mb-4">YesAladin 회원 가입</h2>
             <div class="mb-3">
               <label class="form-label">이름</label>
-              <input type="text" class="form-control" id="name" th:name="name" placeholder="이름"
-                     pattern="^.*(?=.*[가-힣a-z])(?=^.{2,200}).*$"
+              <input type="text" class="form-control" id="name" th:name="name" placeholder="이름은 한글 또는 영어 2자에서 50자까지 입력 가능합니다."
+                     pattern="^.*(?=.*[가-힣a-z])(?=^.{2,50}).*$"
                      required>
-              <div class="invalid-feedback">
-                이름을 입력해주세요.
-              </div>
+              <div class="error" th:if="${#fields.hasErrors('name')}" th:errors="*{name}">name</div>
             </div>
             <div class="mb-3">
               <label class="form-label">닉네임</label>
               <input type="text" class="form-control" id="nickname" th:name="nickname"
                      pattern="^[가-힣ㄱ-ㅎa-zA-Z0-9._-]{2,15}$"
-                     placeholder="숫자, 영어, 한국어와 언더스코어, 공백을 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다." required>
-              <div class="invalid-feedback">
-                숫자, 영어, 한국어와 언더스코어, 공백을 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다.
-              </div>
+                     placeholder="숫자, 영어, 한국어와 언더스코어를 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다." required>
+              <div class="error" th:if="${#fields.hasErrors('nickname')}" th:errors="*{nickname}">nickname</div>
               <div class="button-box">
                 <button class="nicknameCheckBtn" id="nicknameCheckBtn" type="button" onclick="nicknameCheck()">중복 확인</button>
               </div>
@@ -74,9 +70,7 @@
               <input type="text" class="form-control" id="loginId" th:name="loginId"
                      pattern="/([a-zA-Z0-9]{8,15})/g"
                      placeholder="아이디는 영문 또는 숫자로 8자 이상 15자 이하만 가능 합니다." required>
-              <div class="invalid-feedback">
-                아이디는 영문 또는 숫자로 8자 이상 15자 이하만 가능 합니다.
-              </div>
+              <div class="error" th:if="${#fields.hasErrors('loginId')}" th:errors="*{loginId}">loginId</div>
               <div class="button-box">
                 <button class="loginIdCheckBtn" id="loginIdCheckBtn" type="button" onclick="loginIdCheck()">중복 확인</button>
               </div>
@@ -86,9 +80,7 @@
               <input type="email" class="form-control" id="email" th:name="email" placeholder="이메일"
                      pattern="^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$"
                      required>
-              <div class="invalid-feedback">
-                이메일 주소를 입력해주세요.
-              </div>
+              <div class="error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}">email</div>
               <div class="button-box">
                 <button class="emailCheckBtn" id="emailCheckBtn" type="button" onclick="emailCheck()">중복 확인</button>
               </div>
@@ -98,9 +90,7 @@
               <input type="text" class="form-control" id="phone" th:name="phone"
                      pattern="([0-9]{11})"
                      placeholder="휴대폰 번호 ex) 01012345678" required>
-              <div class="invalid-feedback">
-                휴대폰 번호를 - 없이 11자 입력해주세요.
-              </div>
+              <div class="error" th:if="${#fields.hasErrors('phone')}" th:errors="*{phone}">phone</div>
               <div class="button-box">
                 <button class="phoneCheckBtn" id="phoneCheckBtn" type="button" onclick="phoneCheck()">중복 확인</button>
               </div>
@@ -113,9 +103,6 @@
                          pattern="^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$"
                          placeholder="Password"
                          autocomplete="off" required>
-                  <div class="invalid-feedback">
-                    password는 최소 8자, 하나 이상의 문자와 하나의 숫자 및 하나의 특수 문자로 입력해주세요.
-                  </div>
                 </div>
               </div>
               <div class="mb-3">
@@ -123,26 +110,38 @@
                 <div class="input-group input-group-flat">
                   <input type="password" class="form-control" id="passwordCheck"
                          th:name="passwordCheck" placeholder="Password 확인"
-                         pattern="^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$"
+                         pattern="^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,20}$"
                          autocomplete="off" required>
-                  <div class="invalid-feedback">
-                    password는 최소 8자, 하나 이상의 문자와 하나의 숫자 및 하나의 특수 문자로 입력해주세요.
-                  </div>
+                <div class="error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}">PASSWORD</div>
                 </div>
                 <div class="button-box">
                   <button class="passwordCheckBtn" id="passwordCheckBtn" type="button" onclick="passwordCheckEvent()">비밀번호 확인</button>
                 </div>
               </div>
             </div>
+
             <div class="mb-3">
               <label class="form-label">생년월일</label>
-              <input type="text" class="form-control" id="birth" placeholder="예시: 20230101"
-                     pattern="([0-9]{8})"
-                     th:name="birth" required>
-              <div class="invalid-feedback">
-                생년월일을 정확하게 입력해주세요.
+              <div class="input-icon">
+                <span class="input-icon-addon"><!-- Download SVG icon from http://tabler-icons.io/i/calendar -->
+                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                       viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                       stroke-linecap="round" stroke-linejoin="round"><path stroke="none"
+                                                                            d="M0 0h24v24H0z"
+                                                                            fill="none"></path><rect
+                      x="4" y="5" width="16" height="16" rx="2"></rect><line x1="16" y1="3" x2="16"
+                                                                             y2="7"></line><line
+                      x1="8" y1="3" x2="8" y2="7"></line><line x1="4" y1="11" x2="20"
+                                                               y2="11"></line><line x1="11" y1="15"
+                                                                                    x2="12"
+                                                                                    y2="15"></line><line
+                      x1="12" y1="15" x2="12" y2="18"></line></svg>
+                </span>
+                <input type="date" class="form-control" name="birth"
+                       id="datepicker-icon-prepend" value="" required>
               </div>
             </div>
+            <div class="error" th:if="${#fields.hasErrors('birth')}" th:errors="*{birth}">birth</div>
             <div class="mb-3">
               <label class="form-label">성별</label>
               <div class="row g-2">
@@ -152,11 +151,14 @@
                     <option value="MALE">남성</option>
                     <option value="FEMALE">여성</option>
                   </select>
-                  <div class="invalid-feedback">
-                    성별을 선택해주세요.
-                  </div>
+                  <div class="error" th:if="${#fields.hasErrors('gender')}" th:errors="*{gender}">gender</div>
                 </div>
               </div>
+            </div>
+            <div class="button-box">
+              <button class="finalCheckBtn" id="finalCheckBtn" type="button" onclick="finalCheckEvent()">입력 완료 확인</button>
+              <button class="againCheckBtn" id="againCheckBtn" type="button" onclick="againInputCheckEvent()">다시 입력하시겠습니까?</button>
+            </div>
             </div>
             <div class="form-footer">
               <button type="submit" class="btn btn-primary w-100" id="createAccountBtn" disabled>Create new account</button>
@@ -173,58 +175,10 @@
   <!-- TODO 4 : footer -->
   <div th:replace="~{common/fragments/footer :: fragment-footer}"></div>
 </div>
-<script>
-  window.addEventListener('load', () => {
-    const signupForm = document.getElementsByClassName('signup-form');
-
-    let emptyRegex = /\s/g;
-    let nameRegex = /^.*(?=.*[가-힣a-z])(?=^.{2,200}).*$/;
-    let nicknameRegex = /^[가-힣ㄱ-ㅎa-zA-Z0-9._-]{2,15}$/;
-    let loginIdRegex = /([a-zA-Z0-9]{8,15})/g;
-    let birthdayRegex = /^.*(?=.*\d)(?=^.{6}).*$/;
-    let phoneRegex = /^\d{11}$/;
-
-    Array.prototype.filter.call(signupForm, (signupForm) => {
-      signupForm.addEventListener('submit', function (event) {
-        if (signupForm.checkValidity() === false) {
-          event.preventDefault();
-          event.stopPropagation();
-        }
-
-        let nameVal = document.getElementById('name').value;
-        if (!nameRegex.test(nameVal) || emptyRegex.test(nameVal)) {
-          alert('이름을 올바르게 입력해주세요.')
-          return false;
-        }
-
-        let nicknameVal = document.getElementById('nickname').value;
-        if (!nicknameRegex.test(nicknameVal) || emptyRegex.test(nicknameVal)) {
-          alert('숫자, 영어, 한국어와 언더스코어, 공백을 허용하며 최소 2자 이상의 15자 이하의 닉네임만 가능합니다.');
-          return false;
-        }
-
-        let loginIdVal = document.getElementById('loginId').value;
-        if (!loginIdRegex.test(loginIdVal) || emptyRegex.test(loginIdVal)) {
-          alert('아이디는 영문 또는 숫자로(조합 가능) 8자 이상 15자 이하만 가능 합니다.');
-          return false;
-        }
-
-        let birthdayVal = document.getElementById('birth').value;
-        if (!birthdayRegex.test(birthdayVal) || emptyRegex.test(birthdayVal)) {
-          alert('생년월일 8자를 - 없이 입력해주세요. ex) 20230101');
-          return false;
-        }
-
-        let phoneVal = document.getElementById('phone').value;
-        if (!phoneRegex.test(phoneVal) || emptyRegex.test(phoneVal)) {
-          alert('휴대폰 번호를 - 없이 11자 입력해주세요.');
-          return false;
-        }
-
-        signupForm.classList.add('was-validated');
-      }, false);
-    });
-  }, false);
-</script>
+<style>
+  .error {
+    color: red;
+  }
+</style>
 </body>
 </html>


### PR DESCRIPTION
html 자체에서 걸어둔 정규식과 import한 js상에 정규식이 의도한대로 동작하지 않고 자꾸 뚫려서 dto에 걸려있는 `@Valid`를 기준으로 `ModelAndView`, `@ModelAttribute`를 섞어서 다시 form 화면으로 돌아가 input 태그 하단에 error 메시지를 붉은색으로 첨가하였습니다.

OAuth2 Login 시 추가 정보 입력 후 자사 회원등록 form 페이지는 일반 회원가입 페이지와 달리, provider에서 받은 code로 회원 정보를 가져오는 왔다갔다하는 flow를 타고있어 form valid 예외시 다른 메시지를 첨부하여 bad request 에러 페이지로 돌리도록 했습니다. 이게 최선입니다.