### PR TITLE
Fix: token reissue time 매 1분마다 시도로 변경

### DIFF
--- a/src/main/java/shop/yesaladin/front/interceptor/ReissueTokenInterceptor.java
+++ b/src/main/java/shop/yesaladin/front/interceptor/ReissueTokenInterceptor.java
@@ -36,7 +36,7 @@ public class ReissueTokenInterceptor implements HandlerInterceptor {
     private final CookieUtils cookieUtils;
 
     private static final String X_EXPIRE_HEADER = "X-Expire";
-    private static final long TIME_TO_REISSUE = Duration.ofMinutes(5).toSeconds();
+    private static final long TIME_TO_REISSUE = Duration.ofMinutes(59).toSeconds();
 
     /**
      * JWT Token 재발급을 위한 기능입니다.


### PR DESCRIPTION
매 1분마다 토큰을 재발급합니다. 인증 서버에서도 토큰의 유효시간이 60분으로 변경되었으니 양쪽 다 pull 받아서 작업하세요!